### PR TITLE
improve channel send/receive performance

### DIFF
--- a/GoPerf/go_perf_chan.go
+++ b/GoPerf/go_perf_chan.go
@@ -1,0 +1,20 @@
+package main
+
+func main() {
+    count := 1000000
+    ch := make(chan int, 1)
+    for i := 0; i < count; i++ {
+      go func(i int){
+        ch <- i
+      }(i)
+    }
+
+    for i := 0; i < count; i++ {
+        select {
+        case i := <-ch:
+          if i == count-1 {
+            break
+          }
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,10 @@ import PackageDescription
 
 let package = Package(
     name: "Prorsum",
+    targets: [
+        Target(name: "Prorsum"),
+        Target(name: "Performance", dependencies: ["Prorsum"])
+    ],
     dependencies: [
         .Package(url: "https://github.com/Zewo/CHTTPParser.git", majorVersion: 0, minor: 14)
     ]

--- a/Sources/Performance/Channel.swift
+++ b/Sources/Performance/Channel.swift
@@ -1,0 +1,44 @@
+//
+//  Channel.swift
+//  Prorsum
+//
+//  Created by Yuki Takei on 2016/11/28.
+//
+//
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
+import Foundation
+import Prorsum
+
+
+func channelTest(){
+    print("--- [Performance] Channel<Eelement> Millions of roundtrips ---")
+    let start = Date()
+    let count = 1000000
+
+    let ch = Channel<Int>.make(capacity: 1)
+    
+    for i in 0..<count {
+        go {
+            try! ch.send(i)
+        }
+    }
+    
+    forSelect { done in
+        when(ch) {
+            if $0 == count-1 {
+                done()
+            }
+        }
+    }
+
+    let timeElapsed = -start.timeIntervalSinceNow
+
+    print("done, Time Elapsed: \(timeElapsed)")
+    print("")
+}

--- a/Sources/Performance/main.swift
+++ b/Sources/Performance/main.swift
@@ -1,0 +1,38 @@
+//
+//  main.swift
+//  Prorsum
+//
+//  Created by Yuki Takei on 2016/11/28.
+//
+//
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
+import Foundation
+
+let allTests = [
+    channelTest
+]
+
+if CommandLine.arguments.count >= 1 {
+    for i in 0..<allTests.count {
+        allTests[i]()
+    }
+    exit(0)
+}
+
+let testTarget = CommandLine.arguments[1]
+
+switch testTarget {
+case "channel":
+allTests[0]()
+default:
+    print("unknow pref.")
+    exit(1)
+}
+
+print("All items are completed.")

--- a/Sources/Prorsum/Go/Prorsum.swift
+++ b/Sources/Prorsum/Go/Prorsum.swift
@@ -1,14 +1,30 @@
 import Foundation
 import Dispatch
 
-let schedulerQ = DispatchQueue(label: "prorsum.scheduler.queue", attributes: .concurrent)
+private let serialSchedulerQ = DispatchQueue(label: "prorsum.scheduler.serial-queue")
 
-public func go(_ routine: @autoclosure @escaping (Void) -> Void){
-    schedulerQ.async(execute: routine)
+private let concurrentSchedulerQ = DispatchQueue(label: "prorsum.scheduler.concurrent-queue", attributes: .concurrent)
+
+public enum DispatchConcurrentType {
+    case serial
+    case concurrent
 }
 
-public func go(_ routine: @escaping (Void) -> Void){
-    schedulerQ.async(execute: routine)
+public func go(type: DispatchConcurrentType = .concurrent, _ routine: @autoclosure @escaping (Void) -> Void){
+    _go(type, routine)
+}
+
+public func go(type: DispatchConcurrentType = .concurrent, _ routine: @escaping (Void) -> Void){
+    _go(type, routine)
+}
+
+private func _go(_ type: DispatchConcurrentType, _ routine: @escaping (Void) -> Void){
+    switch type {
+    case .concurrent:
+        concurrentSchedulerQ.async(execute: routine)
+    case .serial:
+        serialSchedulerQ.async(execute: routine)
+    }
 }
 
 public func gomain(_ routine: @autoclosure @escaping (Void) -> Void) {

--- a/Sources/Prorsum/Go/Queue.swift
+++ b/Sources/Prorsum/Go/Queue.swift
@@ -1,0 +1,61 @@
+//
+//  Queue.swift
+//  Prorsum
+//
+//  Created by Yuki Takei on 2016/11/29.
+//
+//
+
+public class QueueNode<T> {
+    public let value: T
+    public var next: QueueNode?
+    
+    public init(_ newvalue: T) {
+        self.value = newvalue
+    }
+}
+
+public class Queue<T> {
+    
+    public typealias Element = T
+    
+    public private(set) var count = 0
+    
+    public private(set) var front: QueueNode<Element>?
+    
+    public private(set) var back: QueueNode<Element>?
+    
+    public init () {
+        back = nil
+        front = back
+    }
+    
+    public func push (_ value: Element) {
+        let prevBack = back
+        back = QueueNode<T>(value)
+        if front == nil {
+            front = back
+        } else {
+            prevBack?.next = back
+        }
+        count+=1
+    }
+    
+    @discardableResult
+    public func pop () -> Element? {
+        if let newhead = self.front {
+            self.front = newhead.next
+            if newhead.next == nil {
+                back = nil
+            }
+            count-=1
+            return newhead.value
+        } else {
+            return nil
+        }
+    }
+    
+    public func isEmpty() -> Bool {
+        return count > 0
+    }
+}

--- a/Sources/Prorsum/Go/Select.swift
+++ b/Sources/Prorsum/Go/Select.swift
@@ -154,13 +154,13 @@ public func select(_ handler: (Void) -> Void){
 }
 
 public func when<T>(_ chan: Channel<T>, _ handler: @escaping (T) -> Void){
-    if let sel = Select.stack.top {
+    if let sel = Select.stack.front?.value {
         sel.when(chan, handler)
     }
 }
 
 public func otherwise(_ handler: @escaping (Void) -> Void){
-    if let sel = Select.stack.top {
+    if let sel = Select.stack.front?.value {
         sel.otherwise(handler)
     }
 }

--- a/Sources/Prorsum/Go/Stack.swift
+++ b/Sources/Prorsum/Go/Stack.swift
@@ -6,39 +6,46 @@
 //
 //
 
-class Stack<T> {
+public class StackNode<T> {
+    public let value: T
+    public var next: StackNode?
     
-    var stackArray: [T]
-    
-    public var top: T? {
-        return stackArray.first
+    public init(_ newvalue: T) {
+        self.value = newvalue
     }
+}
+
+public class Stack<T> {
     
-    public var count: Int {
-        return stackArray.count
-    }
+    public typealias Element = T
     
-    public init(){
-        stackArray = [T]()
-    }
+    public private(set) var count = 0
+    
+    public private(set) var front: StackNode<Element>?
+    
+    public init () {}
     
     public func push(_ element: T) {
-        stackArray.insert(element, at: 0)
+        let node = StackNode<T>(element)
+        if front == nil {
+            front = node
+        } else {
+            let prevFront = front
+            front = node
+            front?.next = prevFront
+        }
+        count+=1
     }
     
     @discardableResult
     public func pop() -> T? {
-        if stackArray.count > 0 {
-            return stackArray.removeFirst()
+        if let front = self.front {
+            self.front = self.front?.next
+            count-=1
+            return front.value
         } else {
             return nil
         }
-    }
-}
-
-extension Stack: CustomStringConvertible {
-    public var description: String {
-        return "\(self.stackArray)"
     }
 }
 

--- a/Tests/ProrsumTests/SelectTests.swift
+++ b/Tests/ProrsumTests/SelectTests.swift
@@ -53,16 +53,17 @@ class SelectTests: XCTestCase {
         
         go {
             try! ch.send(1)
-            try! ch.send(1)
-            try! ch.send(1)
+            try! ch.send(2)
+            try! ch.send(3)
             try! doneCh.send("done")
         }
-
+        
+        var i = 0
         forSelect { done in
             when(ch) {
-                XCTAssertEqual($0, 1)
-                XCTAssertEqual($0, 1)
-                XCTAssertEqual($0, 1)
+                i+=1
+                print($0)
+                XCTAssertEqual($0, i)
             }
 
             when(doneCh) {


### PR DESCRIPTION
1. Use Queue<T> to store msgs buffer instead of Swift.Array due to perfomance improving
2. Fix deadlock in the Channel<T>.send method
3. Enable to choose concurrensy type of dispatch performing from serial or concurrent before run 'go'