### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A WaitGroup waits for a collection of GCD operations to finish. The main GCD ope
 
 
 ```swift
-let wg = WaitGrpup()
+let wg = WaitGroup()
 
 wg.add(1)
 go {


### PR DESCRIPTION
Hi,

Found typo in the doc. Please merge this if you'd like.