### PR TITLE
Add port to the Host header if port is set

### DIFF
--- a/Sources/Prorsum/HTTP/HTTPClient.swift
+++ b/Sources/Prorsum/HTTP/HTTPClient.swift
@@ -96,7 +96,11 @@ public class HTTPClient {
         }
         
         if request.host == nil {
-            request.host = url.host
+            if let host = request.host, let port = url.port {
+                request.host = "\(host):\(port)"
+            } else {
+                request.host = url.host
+            }
         }
         
         if request.accept.isEmpty {

--- a/Sources/Prorsum/HTTP/Serializer/RequestSerializer.swift
+++ b/Sources/Prorsum/HTTP/Serializer/RequestSerializer.swift
@@ -19,7 +19,23 @@ public struct RequestSerializer {
         let newLine: [UInt8] = [13, 10]
         
         let method = "\(request.method)".uppercased()
-        try stream.write("\(method) \(request.url.absoluteString) HTTP/\(request.version.major).\(request.version.minor)".bytes, deadline: deadline)
+
+        // if host is set
+        // build uri from path & query
+        // else use absoluteString
+        //
+        let requestURI: String
+        if request.host != nil {
+            var uri = !request.url.path.isEmpty ? request.url.path : "/" 
+            if let query = request.url.query {
+                uri += "?\(query)"
+            }
+            requestURI = uri
+        } else {
+            requestURI = request.url.absoluteString
+        }
+
+        try stream.write("\(method) \(requestURI) HTTP/\(request.version.major).\(request.version.minor)".bytes, deadline: deadline)
         try stream.write(newLine, deadline: deadline)
         
         for (name, value) in request.headers.headers {

--- a/Tests/ProrsumTests/HTTPClientTests.swift
+++ b/Tests/ProrsumTests/HTTPClientTests.swift
@@ -59,6 +59,14 @@ class HTTPClientTests: XCTestCase {
         XCTAssertEqual(response.statusCode, 200)
     }
     
+    func testRedirectToOtherDomainWithPort() {
+        let client = try! HTTPClient(url: URL(string: "https://httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%3A80")!)
+        try! client.open()
+        let response = try! client.request()
+
+        XCTAssertEqual(response.statusCode, 200)
+    }
+    
     func testRedirectMaxRedirectionExceeded() {
         HTTPClient.maxRedirection = 1
         defer {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc2616#section-14.23

Use path as request-uri if host Header is set
https://tools.ietf.org/html/rfc2616#section-5.1.2